### PR TITLE
Fix checkboxes showing default color

### DIFF
--- a/themes/green_lume/green_lume.css
+++ b/themes/green_lume/green_lume.css
@@ -223,7 +223,7 @@ p a {
 .pm_toggle-checkbox:focus + .pm_toggle-label, .pm_toggle-label:hover {
   background: #292929; }
 
-.pm_toggle-checkbox:checked + .pm_toggle-label:hover, .pm_toggle-checkbox:checked:focus + .pm_toggle-label {
+.pm_toggle-checkbox:checked + .pm_toggle-label, .pm_toggle-checkbox:checked + .pm_toggle-label:hover, .pm_toggle-checkbox:checked:focus + .pm_toggle-label {
   background: #2FBF71; }
 
 .pm_toggle.off .off, .pm_toggle.on .on {


### PR DESCRIPTION
The checkboxes would only show as green if they were hovered over. This makes them always appear green.