### PR TITLE
Themes v4: Clear message view

### DIFF
--- a/templates/@theme-base/_full.scss
+++ b/templates/@theme-base/_full.scss
@@ -123,20 +123,9 @@ details:first-child {
 }
 
 // Email body background, text and links
-.email.message-body-container {
-  [bgcolor], [style*="background"] {
-    background-color: transparent !important;
-
-    * {
-      color: $text_color !important;
-    }
-    a, a * {
-      color: $highlight !important;
-    }
-    a:active, a:focus, a:hover, a:active *, a:focus *, a:hover * {
-      color: lighten($highlight, 5%) !important;
-    } 
-  }
+.message-content.frame.message-frame {
+  background: white;
+  color: black;
 }
 
 // Attachment button

--- a/themes/blue_and_orange/blue_and_orange.css
+++ b/themes/blue_and_orange/blue_and_orange.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #ED7D3A; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(237, 125, 58, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #eb6e23; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #eb6e23; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #eb6e23;
+  border-color: #eb6e23; }
 
 .starbutton {
   fill: #ED7D3A !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #e06014; }
 
+.pm-button--primary {
+  background-color: #ED7D3A;
+  border-color: #ED7D3A; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #ED7D3A; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #ED7D3A;
+  border-color: #ED7D3A; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #eb6e23;
+  border: 1px solid #eb6e23; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #ED7D3A;
   border-color: #ED7D3A; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #ED7D3A; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #ED7D3A; }
 
 .progress-contact {
   color: #ED7D3A; }

--- a/themes/blue_and_orange/blue_and_orange_full.css
+++ b/themes/blue_and_orange/blue_and_orange_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #ED7D3A; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(237, 125, 58, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #eb6e23; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #eb6e23; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #eb6e23;
+  border-color: #eb6e23; }
 
 .starbutton {
   fill: #ED7D3A !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #e06014; }
 
+.pm-button--primary {
+  background-color: #ED7D3A;
+  border-color: #ED7D3A; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #ED7D3A; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #ED7D3A;
+  border-color: #ED7D3A; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #eb6e23;
+  border: 1px solid #eb6e23; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #ED7D3A;
   border-color: #ED7D3A; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #ED7D3A; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #ED7D3A; }
 
 .progress-contact {
   color: #ED7D3A; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #0F4C5C; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #135e72; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #167088;
   background-color: #135e72; }
 
-.bg-white {
+.message-infobox {
   background-color: #0F4C5C; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #167088; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #ED7D3A !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #ef8c51 !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #0F4C5C;
@@ -378,3 +399,6 @@ select.pm-field, select.pm-field-icon-container {
     background: #0F4C5C; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #0F4C5C; }

--- a/themes/dark_bubble_gum/dark_bubble_gum.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #EF2D56; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(239, 45, 86, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #ed1543; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #ed1543; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #ed1543;
+  border-color: #ed1543; }
 
 .starbutton {
   fill: #EF2D56 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #d9103b; }
 
+.pm-button--primary {
+  background-color: #EF2D56;
+  border-color: #EF2D56; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #EF2D56; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #EF2D56;
+  border-color: #EF2D56; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #ed1543;
+  border: 1px solid #ed1543; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #EF2D56;
   border-color: #EF2D56; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #EF2D56; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #EF2D56; }
 
 .progress-contact {
   color: #EF2D56; }

--- a/themes/dark_bubble_gum/dark_bubble_gum_full.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #EF2D56; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(239, 45, 86, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #ed1543; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #ed1543; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #ed1543;
+  border-color: #ed1543; }
 
 .starbutton {
   fill: #EF2D56 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #d9103b; }
 
+.pm-button--primary {
+  background-color: #EF2D56;
+  border-color: #EF2D56; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #EF2D56; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #EF2D56;
+  border-color: #EF2D56; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #ed1543;
+  border: 1px solid #ed1543; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #EF2D56;
   border-color: #EF2D56; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #EF2D56; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #EF2D56; }
 
 .progress-contact {
   color: #EF2D56; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #1C1C1C; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #292929; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #363636;
   background-color: #292929; }
 
-.bg-white {
+.message-infobox {
   background-color: #1C1C1C; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #363636; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #EF2D56 !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #f14569 !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #1C1C1C;
@@ -378,3 +399,6 @@ select.pm-field, select.pm-field-icon-container {
     background: #1C1C1C; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #1C1C1C; }

--- a/themes/deutera_one/deutera_one.css
+++ b/themes/deutera_one/deutera_one.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #ffed00; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(255, 237, 0, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #e6d500; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #e6d500; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #e6d500;
+  border-color: #e6d500; }
 
 .starbutton {
   fill: #ffed00 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #ccbe00; }
 
+.pm-button--primary {
+  background-color: #ffed00;
+  border-color: #ffed00; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #ffed00; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #ffed00;
+  border-color: #ffed00; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #e6d500;
+  border: 1px solid #e6d500; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #ffed00;
   border-color: #ffed00; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #ffed00; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #ffed00; }
 
 .progress-contact {
   color: #ffed00; }

--- a/themes/deutera_one/deutera_one_full.css
+++ b/themes/deutera_one/deutera_one_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #ffed00; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(255, 237, 0, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #e6d500; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #e6d500; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #e6d500;
+  border-color: #e6d500; }
 
 .starbutton {
   fill: #ffed00 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #ccbe00; }
 
+.pm-button--primary {
+  background-color: #ffed00;
+  border-color: #ffed00; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #ffed00; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #ffed00;
+  border-color: #ffed00; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #e6d500;
+  border: 1px solid #e6d500; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #ffed00;
   border-color: #ffed00; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #ffed00; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #ffed00; }
 
 .progress-contact {
   color: #ffed00; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #000076; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #000090; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #0000a9;
   background-color: #000090; }
 
-.bg-white {
+.message-infobox {
   background-color: #000076; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #0000a9; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #ffed00 !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #ffef1a !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #000076;
@@ -378,6 +399,9 @@ select.pm-field, select.pm-field-icon-container {
     background: #000076; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #000076; }
 
 .pm-button--error, .pm-button--primary, .pm-button--warning, .pm-button-blue {
   color: #fff;

--- a/themes/dracula/dracula.css
+++ b/themes/dracula/dracula.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #FF79C6; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(255, 121, 198, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #D8D8D8; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #ff60bb; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #ff60bb; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #ff60bb;
+  border-color: #ff60bb; }
 
 .starbutton {
   fill: #FF79C6 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #ff46b0; }
 
+.pm-button--primary {
+  background-color: #FF79C6;
+  border-color: #FF79C6; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #FF79C6; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #FF79C6;
+  border-color: #FF79C6; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #ff60bb;
+  border: 1px solid #ff60bb; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #FF79C6;
   border-color: #FF79C6; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #FF79C6; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #FF79C6; }
 
 .progress-contact {
   color: #FF79C6; }

--- a/themes/dracula/dracula_full.css
+++ b/themes/dracula/dracula_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #FF79C6; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(255, 121, 198, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #D8D8D8; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #ff60bb; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #ff60bb; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #ff60bb;
+  border-color: #ff60bb; }
 
 .starbutton {
   fill: #FF79C6 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #ff46b0; }
 
+.pm-button--primary {
+  background-color: #FF79C6;
+  border-color: #FF79C6; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #FF79C6; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #FF79C6;
+  border-color: #FF79C6; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #ff60bb;
+  border: 1px solid #ff60bb; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #FF79C6;
   border-color: #FF79C6; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #FF79C6; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #FF79C6; }
 
 .progress-contact {
   color: #FF79C6; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #282a36; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #333545; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #3e4153;
   background-color: #333545; }
 
-.bg-white {
+.message-infobox {
   background-color: #282a36; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #3e4153; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #FF79C6 !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #ff93d1 !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #282a36;
@@ -378,3 +399,6 @@ select.pm-field, select.pm-field-icon-container {
     background: #282a36; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #282a36; }

--- a/themes/green_lume/green_lume.css
+++ b/themes/green_lume/green_lume.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #2FBF71; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(47, 191, 113, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #2aab65; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #2aab65; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #2aab65;
+  border-color: #2aab65; }
 
 .starbutton {
   fill: #2FBF71 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #259659; }
 
+.pm-button--primary {
+  background-color: #2FBF71;
+  border-color: #2FBF71; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #2FBF71; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #2FBF71;
+  border-color: #2FBF71; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #2aab65;
+  border: 1px solid #2aab65; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #2FBF71;
   border-color: #2FBF71; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #2FBF71; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #2FBF71; }
 
 .progress-contact {
   color: #2FBF71; }

--- a/themes/green_lume/green_lume_full.css
+++ b/themes/green_lume/green_lume_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #2FBF71; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(47, 191, 113, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #fff; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #2aab65; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #2aab65; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #2aab65;
+  border-color: #2aab65; }
 
 .starbutton {
   fill: #2FBF71 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #259659; }
 
+.pm-button--primary {
+  background-color: #2FBF71;
+  border-color: #2FBF71; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #2FBF71; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #2FBF71;
+  border-color: #2FBF71; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #2aab65;
+  border: 1px solid #2aab65; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #2FBF71;
   border-color: #2FBF71; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #2FBF71; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #2FBF71; }
 
 .progress-contact {
   color: #2FBF71; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #1C1C1C; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #292929; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #363636;
   background-color: #292929; }
 
-.bg-white {
+.message-infobox {
   background-color: #1C1C1C; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #363636; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #d6d6d6 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #2FBF71 !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #39ce7e !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #1C1C1C;
@@ -378,3 +399,6 @@ select.pm-field, select.pm-field-icon-container {
     background: #1C1C1C; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #d6d6d6; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #1C1C1C; }

--- a/themes/monokai/monokai.css
+++ b/themes/monokai/monokai.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #89C62A; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(137, 198, 42, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #FFF; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #7ab126; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #7ab126; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #7ab126;
+  border-color: #7ab126; }
 
 .starbutton {
   fill: #89C62A !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #6c9c21; }
 
+.pm-button--primary {
+  background-color: #89C62A;
+  border-color: #89C62A; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #89C62A; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #89C62A;
+  border-color: #89C62A; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #7ab126;
+  border: 1px solid #7ab126; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #89C62A;
   border-color: #89C62A; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #89C62A; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #89C62A; }
 
 .progress-contact {
   color: #89C62A; }

--- a/themes/monokai/monokai_full.css
+++ b/themes/monokai/monokai_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #89C62A; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(137, 198, 42, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #FFF; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #7ab126; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #7ab126; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #7ab126;
+  border-color: #7ab126; }
 
 .starbutton {
   fill: #89C62A !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #6c9c21; }
 
+.pm-button--primary {
+  background-color: #89C62A;
+  border-color: #89C62A; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #89C62A; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #89C62A;
+  border-color: #89C62A; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #7ab126;
+  border: 1px solid #7ab126; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #89C62A;
   border-color: #89C62A; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #89C62A; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #89C62A; }
 
 .progress-contact {
   color: #89C62A; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #1D1E1A; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #2a2c26; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #373932;
   background-color: #2a2c26; }
 
-.bg-white {
+.message-infobox {
   background-color: #1D1E1A; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #373932; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #89C62A !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #96d435 !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #1D1E1A;
@@ -378,3 +399,6 @@ select.pm-field, select.pm-field-icon-container {
     background: #1D1E1A; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #1D1E1A; }

--- a/themes/ochin/ochin.css
+++ b/themes/ochin/ochin.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #A8E576; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(168, 229, 118, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #C2C5CA; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #9ae161; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #9ae161; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #9ae161;
+  border-color: #9ae161; }
 
 .starbutton {
   fill: #A8E576 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #8ddd4b; }
 
+.pm-button--primary {
+  background-color: #A8E576;
+  border-color: #A8E576; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #A8E576; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #A8E576;
+  border-color: #A8E576; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #9ae161;
+  border: 1px solid #9ae161; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #A8E576;
   border-color: #A8E576; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #A8E576; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #A8E576; }
 
 .progress-contact {
   color: #A8E576; }

--- a/themes/ochin/ochin_full.css
+++ b/themes/ochin/ochin_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #A8E576; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(168, 229, 118, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #C2C5CA; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #9ae161; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #9ae161; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #9ae161;
+  border-color: #9ae161; }
 
 .starbutton {
   fill: #A8E576 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #8ddd4b; }
 
+.pm-button--primary {
+  background-color: #A8E576;
+  border-color: #A8E576; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #A8E576; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #A8E576;
+  border-color: #A8E576; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #9ae161;
+  border: 1px solid #9ae161; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #A8E576;
   border-color: #A8E576; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #A8E576; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #A8E576; }
 
 .progress-contact {
   color: #A8E576; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #333E4C; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #3d4a5b; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #47576b;
   background-color: #3d4a5b; }
 
-.bg-white {
+.message-infobox {
   background-color: #333E4C; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #47576b; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #A8E576 !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #b6e98b !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #333E4C;
@@ -378,6 +399,9 @@ select.pm-field, select.pm-field-icon-container {
     background: #333E4C; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #333E4C; }
 
 .pm-button--error, .pm-button--primary, .pm-button--warning, .pm-button-blue {
   color: #FFF;

--- a/themes/vitamin_c/vitamin_c.css
+++ b/themes/vitamin_c/vitamin_c.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #FD7400; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(253, 116, 0, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #FFE11A; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #e46800; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #e46800; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #e46800;
+  border-color: #e46800; }
 
 .starbutton {
   fill: #FD7400 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #ca5d00; }
 
+.pm-button--primary {
+  background-color: #FD7400;
+  border-color: #FD7400; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #FD7400; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #FD7400;
+  border-color: #FD7400; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #e46800;
+  border: 1px solid #e46800; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #FD7400;
   border-color: #FD7400; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #FD7400; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #FD7400; }
 
 .progress-contact {
   color: #FD7400; }

--- a/themes/vitamin_c/vitamin_c_full.css
+++ b/themes/vitamin_c/vitamin_c_full.css
@@ -60,6 +60,9 @@
 .conversation.marked::before {
   background: #FD7400; }
 
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+  background: #fff; }
+
 .conversation.item-container.active, .conversation.item-is-selected {
   background: rgba(253, 116, 0, 0.1); }
 
@@ -74,9 +77,14 @@
   fill: #FFE11A; }
 
 .conversation .selectBoxElement-container:hover .item-icon {
+  background-color: transparent;
   border: 1px solid #e46800; }
   .conversation .selectBoxElement-container:hover .item-icon .item-icon-fakecheck-icon {
     fill: #e46800; }
+
+.conversation .selectBoxElement-container:hover .item-checkbox:checked + .item-icon {
+  background-color: #e46800;
+  border-color: #e46800; }
 
 .starbutton {
   fill: #FD7400 !important;
@@ -109,6 +117,21 @@ a:active, a:focus, a:hover,
 .pm-button--link:hover {
   color: #ca5d00; }
 
+.pm-button--primary {
+  background-color: #FD7400;
+  border-color: #FD7400; }
+
+.pm-button--link, .pm-button.pm-button--link {
+  color: #FD7400; }
+
+.pm-button--error, .pm-button--error.pm-button--info, .pm-button--error.pm-button--redborder, .pm-button--primary, .pm-button--primary.pm-button--info, .pm-button--primary.pm-button--redborder, .pm-button--warning, .pm-button--warning.pm-button--info, .pm-button--warning.pm-button--redborder, .pm-button-blue, .pm-button-blue.pm-button--info, .pm-button-blue.pm-button--redborder, .pm-button.pm-button--error, .pm-button.pm-button--primary, .pm-button.pm-button--warning, .pm-button.pm-button-blue {
+  background-color: #FD7400;
+  border-color: #FD7400; }
+
+.is-hover.pm-button--error, .is-hover.pm-button--error.pm-button--info, .is-hover.pm-button--error.pm-button--redborder, .is-hover.pm-button--primary, .is-hover.pm-button--primary.pm-button--info, .is-hover.pm-button--primary.pm-button--redborder, .is-hover.pm-button--warning, .is-hover.pm-button--warning.pm-button--info, .is-hover.pm-button--warning.pm-button--redborder, .pm-button--error.pm-button--info:focus, .pm-button--error.pm-button--info:focus-within, .pm-button--error.pm-button--info:hover, .pm-button--error.pm-button--redborder:focus, .pm-button--error.pm-button--redborder:focus-within, .pm-button--error.pm-button--redborder:hover, .pm-button--error:focus, .pm-button--error:focus-within, .pm-button--error:hover, .pm-button--primary.pm-button--info:focus, .pm-button--primary.pm-button--info:focus-within, .pm-button--primary.pm-button--info:hover, .pm-button--primary.pm-button--redborder:focus, .pm-button--primary.pm-button--redborder:focus-within, .pm-button--primary.pm-button--redborder:hover, .pm-button--primary:focus, .pm-button--primary:focus-within, .pm-button--primary:hover, .pm-button--warning.pm-button--info:focus, .pm-button--warning.pm-button--info:focus-within, .pm-button--warning.pm-button--info:hover, .pm-button--warning.pm-button--redborder:focus, .pm-button--warning.pm-button--redborder:focus-within, .pm-button--warning.pm-button--redborder:hover, .pm-button--warning:focus, .pm-button--warning:focus-within, .pm-button--warning:hover, .pm-button-blue.is-hover, .pm-button-blue.is-hover.pm-button--info, .pm-button-blue.is-hover.pm-button--redborder, .pm-button-blue.pm-button--info:focus, .pm-button-blue.pm-button--info:focus-within, .pm-button-blue.pm-button--info:hover, .pm-button-blue.pm-button--redborder:focus, .pm-button-blue.pm-button--redborder:focus-within, .pm-button-blue.pm-button--redborder:hover, .pm-button-blue:focus, .pm-button-blue:focus-within, .pm-button-blue:hover, .pm-button.is-hover.pm-button--error, .pm-button.is-hover.pm-button--primary, .pm-button.is-hover.pm-button--warning, .pm-button.pm-button--error:focus, .pm-button.pm-button--error:focus-within, .pm-button.pm-button--error:hover, .pm-button.pm-button--primary:focus, .pm-button.pm-button--primary:focus-within, .pm-button.pm-button--primary:hover, .pm-button.pm-button--warning:focus, .pm-button.pm-button--warning:focus-within, .pm-button.pm-button--warning:hover, .pm-button.pm-button-blue.is-hover, .pm-button.pm-button-blue:focus, .pm-button.pm-button-blue:focus-within, .pm-button.pm-button-blue:hover {
+  background: #e46800;
+  border: 1px solid #e46800; }
+
 .pm-toggle-checkbox:checked + .pm-toggle-label:before {
   background: #FD7400;
   border-color: #FD7400; }
@@ -127,6 +150,9 @@ a:active, a:focus, a:hover,
 .pm-table--highlight[data-plan-number="1"] tr th:nth-child(2),
 .pm-table--highlight[data-plan-number="1"] tr:last-child td:nth-child(2) {
   border-color: #FD7400; }
+
+.pm-simple-table-row-th .fill-primary {
+  fill: #FD7400; }
 
 .progress-contact {
   color: #FD7400; }
@@ -164,7 +190,7 @@ body {
 .bg-global-light, kbd {
   background: #004358; }
 
-.conversation.item-container:not(.item-contact):not(.read):not(.active),
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
 .conversation.item-container-row:not(.item-contact):not(.read):not(.active) {
   background: #005672; }
 
@@ -214,20 +240,15 @@ details:first-child {
   border-left: 1px solid #006a8b;
   background-color: #005672; }
 
-.bg-white {
+.message-infobox {
   background-color: #004358; }
 
 .bordered, .bordered-container, .breadcrumb-container {
   border-color: #006a8b; }
 
-.email.message-body-container [bgcolor], .email.message-body-container [style*="background"] {
-  background-color: transparent !important; }
-  .email.message-body-container [bgcolor] *, .email.message-body-container [style*="background"] * {
-    color: #e6eaf0 !important; }
-  .email.message-body-container [bgcolor] a, .email.message-body-container [bgcolor] a *, .email.message-body-container [style*="background"] a, .email.message-body-container [style*="background"] a * {
-    color: #FD7400 !important; }
-  .email.message-body-container [bgcolor] a:active, .email.message-body-container [bgcolor] a:focus, .email.message-body-container [bgcolor] a:hover, .email.message-body-container [bgcolor] a:active *, .email.message-body-container [bgcolor] a:focus *, .email.message-body-container [bgcolor] a:hover *, .email.message-body-container [style*="background"] a:active, .email.message-body-container [style*="background"] a:focus, .email.message-body-container [style*="background"] a:hover, .email.message-body-container [style*="background"] a:active *, .email.message-body-container [style*="background"] a:focus *, .email.message-body-container [style*="background"] a:hover * {
-    color: #ff8218 !important; }
+.message-content.frame.message-frame {
+  background: white;
+  color: black; }
 
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #004358;
@@ -378,3 +399,6 @@ select.pm-field, select.pm-field-icon-container {
     background: #004358; }
   .pm-toggle-label .pm-toggle-label-img {
     fill: #e6eaf0; }
+
+.pm-plans-table-row--highlighted {
+  background-color: #004358; }


### PR DESCRIPTION
Whilst experimenting with having a "dark" or theme based message view, it led to the decision of making it clear and not opinionated towards styling of the contents email.

Addressing all cases of layouts and styles is very challenging and it was breaking a lot newsletter layouts, sometimes making them unreadable.

This update makes the message contents clear by default and will take any styles a newsletter passes to it. Everything else will still be styled with the theme colour scheme.

![Screenshot 2019-12-19 at 02 17 48](https://user-images.githubusercontent.com/12223613/71139341-ce53ca00-2205-11ea-891e-032e3055405f.png)