### PR TITLE
Unread messages fixes for row styles

### DIFF
--- a/templates/@theme-base/_full.scss
+++ b/templates/@theme-base/_full.scss
@@ -77,7 +77,7 @@ body {
 
 // Unread, not active
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: lighten($base, 5%);
 }
 

--- a/templates/@theme-base/_styles.scss
+++ b/templates/@theme-base/_styles.scss
@@ -77,13 +77,13 @@ $boxshadow-main: none;
     background: $highlight;
   }
 
-  &.item-container {
+  &.item-container, &.item-container-row  {
     &:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
       background: $color-standard-text;
     }
   }
 
-  &.item-container.active, &.item-is-selected {
+  &.item-container.selected, &.item-container-row.selected {
     background: rgba($highlight, 0.1);
   }
 

--- a/themes/blue_and_orange/blue_and_orange.css
+++ b/themes/blue_and_orange/blue_and_orange.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #ED7D3A; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(237, 125, 58, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/blue_and_orange/blue_and_orange_full.css
+++ b/themes/blue_and_orange/blue_and_orange_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #ED7D3A; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(237, 125, 58, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #0F4C5C; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #135e72; }
 
 .item-container.active, .item-is-selected {

--- a/themes/dark_bubble_gum/dark_bubble_gum.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #EF2D56; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(239, 45, 86, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/dark_bubble_gum/dark_bubble_gum_full.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #EF2D56; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(239, 45, 86, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #1C1C1C; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #292929; }
 
 .item-container.active, .item-is-selected {

--- a/themes/deutera_one/deutera_one.css
+++ b/themes/deutera_one/deutera_one.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #ffed00; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(255, 237, 0, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/deutera_one/deutera_one_full.css
+++ b/themes/deutera_one/deutera_one_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #ffed00; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(255, 237, 0, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #000076; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #000090; }
 
 .item-container.active, .item-is-selected {

--- a/themes/dracula/dracula.css
+++ b/themes/dracula/dracula.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #FF79C6; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(255, 121, 198, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/dracula/dracula_full.css
+++ b/themes/dracula/dracula_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #FF79C6; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(255, 121, 198, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #282a36; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #333545; }
 
 .item-container.active, .item-is-selected {

--- a/themes/green_lume/green_lume.css
+++ b/themes/green_lume/green_lume.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #2FBF71; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(47, 191, 113, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/green_lume/green_lume_full.css
+++ b/themes/green_lume/green_lume_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #2FBF71; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(47, 191, 113, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #1C1C1C; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #292929; }
 
 .item-container.active, .item-is-selected {

--- a/themes/gruvbox/gruvbox.css
+++ b/themes/gruvbox/gruvbox.css
@@ -62,10 +62,10 @@
 .conversation.marked::before {
   background: #689d6a; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(104, 157, 106, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/gruvbox/gruvbox_full.css
+++ b/themes/gruvbox/gruvbox_full.css
@@ -62,10 +62,10 @@
 .conversation.marked::before {
   background: #689d6a; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(104, 157, 106, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -223,7 +223,7 @@ body {
   background: #282828; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #353535; }
 
 .item-container.active, .item-is-selected {

--- a/themes/inbox/inbox.css
+++ b/themes/inbox/inbox.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #4285F4; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(66, 133, 244, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/monokai/monokai.css
+++ b/themes/monokai/monokai.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #89C62A; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(137, 198, 42, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/monokai/monokai_full.css
+++ b/themes/monokai/monokai_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #89C62A; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(137, 198, 42, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #1D1E1A; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #2a2c26; }
 
 .item-container.active, .item-is-selected {

--- a/themes/ochin/ochin.css
+++ b/themes/ochin/ochin.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #A8E576; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(168, 229, 118, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/ochin/ochin_full.css
+++ b/themes/ochin/ochin_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #A8E576; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(168, 229, 118, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #333E4C; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #3d4a5b; }
 
 .item-container.active, .item-is-selected {

--- a/themes/vitamin_c/vitamin_c.css
+++ b/themes/vitamin_c/vitamin_c.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #FD7400; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(253, 116, 0, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {

--- a/themes/vitamin_c/vitamin_c_full.css
+++ b/themes/vitamin_c/vitamin_c_full.css
@@ -60,10 +60,10 @@
 .conversation.marked::before {
   background: #FD7400; }
 
-.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
+.conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active) {
   background: #fff; }
 
-.conversation.item-container.active, .conversation.item-is-selected {
+.conversation.item-container.selected, .conversation.item-container-row.selected {
   background: rgba(253, 116, 0, 0.1); }
 
 .conversation .item-checkbox:checked + .item-icon {
@@ -221,7 +221,7 @@ body {
   background: #004358; }
 
 .conversation.item-container:not(.item-is-selected):not(.item-contact):not(.read):not(.active),
-.conversation.item-container-row:not(.item-contact):not(.read):not(.active), .squireToolbar-container {
+.conversation.item-container-row:not(.item-is-selected):not(.item-contact):not(.read):not(.active), .squireToolbar-container {
   background: #005672; }
 
 .item-container.active, .item-is-selected {


### PR DESCRIPTION
These fixes address theme styles not applying correctly to the message list items when using the row layout type. This was leading to unread messages going dark on the regular version of the theme and read ones being light on the `full` version.