### PR TITLE
New message will have base background

### DIFF
--- a/templates/@theme-base/_full.scss
+++ b/templates/@theme-base/_full.scss
@@ -221,6 +221,10 @@ details:first-child {
   color: black;
 }
 
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: $highlight;
+}
+
 .squireDropdown-item-label {
   color: $text_color;
 }

--- a/templates/@theme-base/_full.scss
+++ b/templates/@theme-base/_full.scss
@@ -110,6 +110,7 @@ body {
 
 [class*="block-info"] {
   background-color: lighten($base, 10%);
+  color: $text_color;
 }
 
 .fill-global-grey {
@@ -219,6 +220,24 @@ details:first-child {
   background: white;
   color: black;
 }
+
+.squireDropdown-item-label {
+  color: $text_color;
+}
+
+.squireToolbar-action-color {
+  background: transparent;
+}
+
+// This forces the background of a new message to used the base color.
+.angular-squire-iframe body {
+  color: $text_color;
+  background: lighten($base, 5%);
+
+  a {
+    color: $highlight;
+  }
+} 
 
 // Attachment button
 .pm-button, .pm-button--info, .pm-button--redborder {

--- a/templates/@theme-base/_full.scss
+++ b/templates/@theme-base/_full.scss
@@ -241,7 +241,11 @@ details:first-child {
   a {
     color: $highlight;
   }
-} 
+}
+
+.plaintext-editor {
+  color: $text_color;
+}
 
 // Attachment button
 .pm-button, .pm-button--info, .pm-button--redborder {

--- a/templates/@theme-base/_styles.scss
+++ b/templates/@theme-base/_styles.scss
@@ -247,6 +247,12 @@ a:active, a:focus, a:hover,
 
 // Message panel
 
+.angular-squire-iframe body {
+  a {
+    color: $highlight;
+  }
+} 
+
 // Attachment icon
 .fill-pm-blue,
 .message-attachmentIcon .file-outer-icon.is-embedded {

--- a/themes/blue_and_orange/blue_and_orange_full.css
+++ b/themes/blue_and_orange/blue_and_orange_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #167088; }
+  background-color: #167088;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #ED7D3A; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #ED7D3A; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;

--- a/themes/blue_and_orange/blue_and_orange_full.css
+++ b/themes/blue_and_orange/blue_and_orange_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #ED7D3A; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #0F4C5C;
   border-color: #167088;

--- a/themes/dark_bubble_gum/dark_bubble_gum_full.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #363636; }
+  background-color: #363636;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #EF2D56; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #EF2D56; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;

--- a/themes/dark_bubble_gum/dark_bubble_gum_full.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #EF2D56; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #1C1C1C;
   border-color: #363636;

--- a/themes/deutera_one/deutera_one_full.css
+++ b/themes/deutera_one/deutera_one_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #0000a9; }
+  background-color: #0000a9;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #ffed00; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #ffed00; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;

--- a/themes/deutera_one/deutera_one_full.css
+++ b/themes/deutera_one/deutera_one_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #ffed00; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #000076;
   border-color: #0000a9;

--- a/themes/dracula/dracula_full.css
+++ b/themes/dracula/dracula_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #3e4153; }
+  background-color: #3e4153;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #FF79C6; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #FF79C6; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;

--- a/themes/dracula/dracula_full.css
+++ b/themes/dracula/dracula_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #FF79C6; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #282a36;
   border-color: #3e4153;

--- a/themes/green_lume/green_lume_full.css
+++ b/themes/green_lume/green_lume_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #2FBF71; }
 
+.plaintext-editor {
+  color: #d6d6d6; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #1C1C1C;
   border-color: #363636;

--- a/themes/green_lume/green_lume_full.css
+++ b/themes/green_lume/green_lume_full.css
@@ -316,7 +316,8 @@ body {
   color: #d6d6d6; }
 
 [class*="block-info"] {
-  background-color: #363636; }
+  background-color: #363636;
+  color: #d6d6d6; }
 
 .fill-global-grey {
   fill: #2FBF71; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #2FBF71; }
+
+.squireDropdown-item-label {
+  color: #d6d6d6; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #d6d6d6;

--- a/themes/gruvbox/gruvbox_full.css
+++ b/themes/gruvbox/gruvbox_full.css
@@ -318,7 +318,8 @@ body {
   color: #fbf1c7; }
 
 [class*="block-info"] {
-  background-color: #424242; }
+  background-color: #424242;
+  color: #fbf1c7; }
 
 .fill-global-grey {
   fill: #689d6a; }
@@ -394,6 +395,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #689d6a; }
+
+.squireDropdown-item-label {
+  color: #fbf1c7; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #fbf1c7;

--- a/themes/gruvbox/gruvbox_full.css
+++ b/themes/gruvbox/gruvbox_full.css
@@ -411,6 +411,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #689d6a; }
 
+.plaintext-editor {
+  color: #fbf1c7; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #282828;
   border-color: #424242;

--- a/themes/monokai/monokai_full.css
+++ b/themes/monokai/monokai_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #373932; }
+  background-color: #373932;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #89C62A; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #89C62A; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;

--- a/themes/monokai/monokai_full.css
+++ b/themes/monokai/monokai_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #89C62A; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #1D1E1A;
   border-color: #373932;

--- a/themes/ochin/ochin_full.css
+++ b/themes/ochin/ochin_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #A8E576; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #333E4C;
   border-color: #47576b;

--- a/themes/ochin/ochin_full.css
+++ b/themes/ochin/ochin_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #47576b; }
+  background-color: #47576b;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #A8E576; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #A8E576; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;

--- a/themes/vitamin_c/vitamin_c_full.css
+++ b/themes/vitamin_c/vitamin_c_full.css
@@ -409,6 +409,9 @@ details:first-child {
   .angular-squire-iframe body a {
     color: #FD7400; }
 
+.plaintext-editor {
+  color: #e6eaf0; }
+
 .pm-button, .pm-button--info, .pm-button--redborder {
   background: #004358;
   border-color: #006a8b;

--- a/themes/vitamin_c/vitamin_c_full.css
+++ b/themes/vitamin_c/vitamin_c_full.css
@@ -316,7 +316,8 @@ body {
   color: #e6eaf0; }
 
 [class*="block-info"] {
-  background-color: #006a8b; }
+  background-color: #006a8b;
+  color: #e6eaf0; }
 
 .fill-global-grey {
   fill: #FD7400; }
@@ -392,6 +393,15 @@ details:first-child {
 .message-content.frame.message-frame {
   background: white;
   color: black; }
+
+.block-info-standard, .bodyDecrypted blockquote {
+  border-color: #FD7400; }
+
+.squireDropdown-item-label {
+  color: #e6eaf0; }
+
+.squireToolbar-action-color {
+  background: transparent; }
 
 .angular-squire-iframe body {
   color: #e6eaf0;


### PR DESCRIPTION
The new message panel will have have the base colour on full themes. Reading email panels are not affected due to how challenging it is to predict the markup on incoming emails. A large number of emails would become unreadable if `$base` is put in place.

Fixes issue where plain text emails background would not contrast enough with background. Related to issue #46.

![Screenshot 2020-06-04 at 19 46 03](https://user-images.githubusercontent.com/12223613/83799560-e62ce680-a69d-11ea-9b3b-2f615cd62eae.png)
