### PR TITLE
Encryption lock colour fix

### DIFF
--- a/templates/@theme-base/_full.scss
+++ b/templates/@theme-base/_full.scss
@@ -95,6 +95,11 @@ body {
   border-color: $text_color;
 }
 
+// Encryption icon
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white;
+}
+
 // Message items
 .conversation {
   border-color: lighten($base, 10%);

--- a/templates/@theme-base/_styles.scss
+++ b/templates/@theme-base/_styles.scss
@@ -155,6 +155,20 @@ $boxshadow-main: none;
   fill: $highlight;
 }
 
+// Encryption icon
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: darken($highlight, 5%);
+}
+
+.encryptionStatus .color-pm-blue svg {
+  color: darken($highlight, 5%);
+  fill: darken($highlight, 5%);
+}
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black;
+}
+
 // Highlighted text (seen when multiple messages are selected)
 .color-pm-blue {
   color: $highlight;

--- a/themes/blue_and_orange/blue_and_orange.css
+++ b/themes/blue_and_orange/blue_and_orange.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #ED7D3A; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #eb6e23; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #eb6e23;
+  fill: #eb6e23; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #ED7D3A; }
 

--- a/themes/blue_and_orange/blue_and_orange_full.css
+++ b/themes/blue_and_orange/blue_and_orange_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #ED7D3A; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #eb6e23; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #eb6e23;
+  fill: #eb6e23; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #ED7D3A; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #167088; }

--- a/themes/dark_bubble_gum/dark_bubble_gum.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #EF2D56; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #ed1543; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #ed1543;
+  fill: #ed1543; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #EF2D56; }
 

--- a/themes/dark_bubble_gum/dark_bubble_gum_full.css
+++ b/themes/dark_bubble_gum/dark_bubble_gum_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #EF2D56; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #ed1543; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #ed1543;
+  fill: #ed1543; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #EF2D56; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #363636; }

--- a/themes/deutera_one/deutera_one.css
+++ b/themes/deutera_one/deutera_one.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #ffed00; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #e6d500; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #e6d500;
+  fill: #e6d500; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #ffed00; }
 

--- a/themes/deutera_one/deutera_one_full.css
+++ b/themes/deutera_one/deutera_one_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #ffed00; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #e6d500; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #e6d500;
+  fill: #e6d500; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #ffed00; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #0000a9; }

--- a/themes/dracula/dracula.css
+++ b/themes/dracula/dracula.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #FF79C6; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #ff60bb; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #ff60bb;
+  fill: #ff60bb; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #FF79C6; }
 

--- a/themes/dracula/dracula_full.css
+++ b/themes/dracula/dracula_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #FF79C6; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #ff60bb; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #ff60bb;
+  fill: #ff60bb; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #FF79C6; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #3e4153; }

--- a/themes/green_lume/green_lume.css
+++ b/themes/green_lume/green_lume.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #2FBF71; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #2aab65; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #2aab65;
+  fill: #2aab65; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #2FBF71; }
 

--- a/themes/green_lume/green_lume_full.css
+++ b/themes/green_lume/green_lume_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #2FBF71; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #2aab65; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #2aab65;
+  fill: #2aab65; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #2FBF71; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #d6d6d6; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #363636; }

--- a/themes/gruvbox/gruvbox.css
+++ b/themes/gruvbox/gruvbox.css
@@ -115,6 +115,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #689d6a; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #5d8f5f; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #5d8f5f;
+  fill: #5d8f5f; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #689d6a; }
 

--- a/themes/gruvbox/gruvbox_full.css
+++ b/themes/gruvbox/gruvbox_full.css
@@ -115,6 +115,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #689d6a; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #5d8f5f; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #5d8f5f;
+  fill: #5d8f5f; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #689d6a; }
 
@@ -306,6 +316,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #fbf1c7; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #424242; }

--- a/themes/inbox/inbox.css
+++ b/themes/inbox/inbox.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #4285F4; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #2a75f3; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #2a75f3;
+  fill: #2a75f3; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #4285F4; }
 

--- a/themes/monokai/monokai.css
+++ b/themes/monokai/monokai.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #89C62A; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #7ab126; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #7ab126;
+  fill: #7ab126; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #89C62A; }
 

--- a/themes/monokai/monokai_full.css
+++ b/themes/monokai/monokai_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #89C62A; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #7ab126; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #7ab126;
+  fill: #7ab126; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #89C62A; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #373932; }

--- a/themes/ochin/ochin.css
+++ b/themes/ochin/ochin.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #A8E576; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #9ae161; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #9ae161;
+  fill: #9ae161; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #A8E576; }
 

--- a/themes/ochin/ochin_full.css
+++ b/themes/ochin/ochin_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #A8E576; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #9ae161; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #9ae161;
+  fill: #9ae161; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #A8E576; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #47576b; }

--- a/themes/vitamin_c/vitamin_c.css
+++ b/themes/vitamin_c/vitamin_c.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #FD7400; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #e46800; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #e46800;
+  fill: #e46800; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #FD7400; }
 

--- a/themes/vitamin_c/vitamin_c_full.css
+++ b/themes/vitamin_c/vitamin_c_full.css
@@ -113,6 +113,16 @@
 .starbutton:focus, .starbutton:hover {
   fill: #FD7400; }
 
+.autocompleteEmailsItem-icon svg.encryptionIcon {
+  fill: #e46800; }
+
+.encryptionStatus .color-pm-blue svg {
+  color: #e46800;
+  fill: #e46800; }
+
+.encryptionStatus .color-global-grey-dm svg {
+  color: black; }
+
 .color-pm-blue {
   color: #FD7400; }
 
@@ -304,6 +314,9 @@ body {
 
 .composerInputMeta-overlay-fakefield {
   border-color: #e6eaf0; }
+
+.encryptionStatus .color-global-grey-dm:not(.color-pm-blue) svg {
+  color: white; }
 
 .conversation {
   border-color: #006a8b; }


### PR DESCRIPTION
Fixes the colour of the encryption lock to differentiate between end-to-end encrypted emails and zero access stored, having the same behaviour of ProtonMail's default theme. 

Solves #51.